### PR TITLE
[issue-5] Using request count per target as only scaling policy

### DIFF
--- a/templates/bbb-on-aws-frontendapps.template.yaml
+++ b/templates/bbb-on-aws-frontendapps.template.yaml
@@ -664,29 +664,13 @@ Resources:
       PolicyType: TargetTrackingScaling
       ScalingTargetId: !Ref BBBgreenlightServiceScalingTarget
       TargetTrackingScalingPolicyConfiguration:
-        TargetValue: 20
+        TargetValue: 80
         DisableScaleIn: False
         ScaleInCooldown: 15
         ScaleOutCooldown: 15
-        CustomizedMetricSpecification:
-          MetricName: RequestCount
-          Statistic: Sum
-          Namespace: AWS/ApplicationELB
-
-  BBBgreenlightServiceScalingPolicyCPU:
-    Type: AWS::ApplicationAutoScaling::ScalingPolicy
-    DependsOn: BBBAutoscalingRole
-    Properties:
-      PolicyName: BBBgreenlightTargetTrackingPolicyCPU
-      PolicyType: TargetTrackingScaling
-      ScalingTargetId: !Ref BBBgreenlightServiceScalingTarget
-      TargetTrackingScalingPolicyConfiguration:
-        TargetValue: 75
-        DisableScaleIn: False
-        ScaleInCooldown: 60
-        ScaleOutCooldown: 15
         PredefinedMetricSpecification:
-          PredefinedMetricType: ECSServiceAverageCPUUtilization
+          PredefinedMetricType: ALBRequestCountPerTarget
+          ResourceLabel: !Join ["/", [!GetAtt BBBFrontendALB.LoadBalancerFullName, !GetAtt BBBFrontendTG.TargetGroupFullName]]
 
   BBBScaleliteTaskdefinition:
     Type: AWS::ECS::TaskDefinition


### PR DESCRIPTION
Closes #5 

*Description of changes:*

* Remove CPU Scaling Policy
* Fix Request Count Scaling Policy
* Increase request count target to 80 as 100 was still a manageable target

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
