### PR TITLE
Fix/fargate deploy errors

### DIFF
--- a/templates/bbb-on-aws-frontendapps.template.yaml
+++ b/templates/bbb-on-aws-frontendapps.template.yaml
@@ -906,8 +906,8 @@ Resources:
       Family: !Join [ "", [ !Ref "AWS::StackName", -scalelite-handle-server ] ]
       ExecutionRoleArn: !Ref BBBScaleliteExecutionRole
       NetworkMode: !If [ BBBECSFargate, awsvpc, !Ref "AWS::NoValue"]
-      Memory: 256
-      Cpu: 128
+      Memory: 512
+      Cpu: 256
       RequiresCompatibilities: 
         !If 
         - BBBECSFargate

--- a/templates/bbb-on-aws-frontendapps.template.yaml
+++ b/templates/bbb-on-aws-frontendapps.template.yaml
@@ -552,7 +552,8 @@ Resources:
       RequiresCompatibilities: 
         !If 
         - BBBECSFargate
-        - FARGATE
+        -
+          - FARGATE
         - !Ref "AWS::NoValue"
       ContainerDefinitions:
         - Name: greenlight
@@ -690,7 +691,8 @@ Resources:
       RequiresCompatibilities: 
         !If 
         - BBBECSFargate
-        - FARGATE
+        -
+          - FARGATE
         - !Ref "AWS::NoValue"
       Volumes:
         - Name: !Join [ "", [ scalelite-recordings-volume-spool, !Ref BBBEnvironmentStage ] ]
@@ -909,7 +911,8 @@ Resources:
       RequiresCompatibilities: 
         !If 
         - BBBECSFargate
-        - FARGATE
+        -
+          - FARGATE
         - !Ref "AWS::NoValue"
       ContainerDefinitions:
         - Name: scalelite-handle-server


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Fixed two errors when deploying with "fargate" as BBBECSInstanceType.  First error was caused by an incorrect structure for the RequiresCompatibilities node.  

Second error was invalid Memory/Cpu values for Fargate in BBBScaleliteAddServerTaskdefinition.  As per https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html min values are 256 for CPU and 512 for memory 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
