### PR TITLE
Fixed errors when setting BBBEnvironmentType as "single"

### DIFF
--- a/bbb-on-aws-master.template.yaml
+++ b/bbb-on-aws-master.template.yaml
@@ -918,6 +918,10 @@ Resources:
           Fn::GetAtt:
             - BBBTurnStack
             - Outputs.BBBTurnSecret
+        BBBTurnHostnameParameter:
+          Fn::GetAtt:
+            - BBBTurnStack
+            - Outputs.BBBTurnHostnameParameter
         BBBNotificationTopic:
           Ref: BBBNotificationTopic
         BBBSystemLogsGroupArn:

--- a/templates/bbb-on-aws-securitygroups.template.yaml
+++ b/templates/bbb-on-aws-securitygroups.template.yaml
@@ -136,7 +136,6 @@ Resources:
 
   BBBApplicationSecurityGroup:
     Type: AWS::EC2::SecurityGroup
-    Condition: BBBScalableEnvironment
     Properties:
       VpcId:
         Ref: BBBVPC
@@ -144,7 +143,6 @@ Resources:
 
   BBBApplicationSecurityGroupWebSSLPort:
     Type: AWS::EC2::SecurityGroupIngress
-    Condition: BBBScalableEnvironment
     Properties:
       CidrIp: 0.0.0.0/0
       IpProtocol: tcp
@@ -154,7 +152,6 @@ Resources:
 
   BBBApplicationSecurityGroupWebPlainPort:
     Type: AWS::EC2::SecurityGroupIngress
-    Condition: BBBScalableEnvironment
     Properties:
       CidrIp: 0.0.0.0/0
       IpProtocol: tcp
@@ -164,7 +161,6 @@ Resources:
 
   BBBApplicationSecurityGroupVCPorts:
     Type: AWS::EC2::SecurityGroupIngress
-    Condition: BBBScalableEnvironment
     Properties:
       CidrIp: 0.0.0.0/0
       IpProtocol: udp
@@ -174,7 +170,6 @@ Resources:
 
   BBBApplicationSecurityGroupTurnPorts:
     Type: AWS::EC2::SecurityGroupIngress
-    Condition: BBBScalableEnvironment
     Properties:
       SourceSecurityGroupId: !Ref BBBTurnSecurityGroup
       IpProtocol: udp
@@ -184,7 +179,6 @@ Resources:
 
   BBBTurnSecurityGroup:
     Type: AWS::EC2::SecurityGroup
-    Condition: BBBScalableEnvironment
     Properties:
       VpcId:
         Ref: BBBVPC
@@ -192,7 +186,6 @@ Resources:
 
   BBBTurnSecurityGroupWebSSLPort:
     Type: AWS::EC2::SecurityGroupIngress
-    Condition: BBBScalableEnvironment
     Properties:
       CidrIp: 0.0.0.0/0
       IpProtocol: tcp
@@ -202,7 +195,6 @@ Resources:
 
   BBBTurnSecurityGroupWebPlainPort:
     Type: AWS::EC2::SecurityGroupIngress
-    Condition: BBBScalableEnvironment
     Properties:
       CidrIp: 0.0.0.0/0
       IpProtocol: tcp
@@ -212,7 +204,6 @@ Resources:
 
   BBBTurnSecurityGroupWebSSLUDPPort:
     Type: AWS::EC2::SecurityGroupIngress
-    Condition: BBBScalableEnvironment
     Properties:
       CidrIp: 0.0.0.0/0
       IpProtocol: udp
@@ -222,7 +213,6 @@ Resources:
 
   BBBTurnSecurityGroupWebPlainUDPPort:
     Type: AWS::EC2::SecurityGroupIngress
-    Condition: BBBScalableEnvironment
     Properties:
       CidrIp: 0.0.0.0/0
       IpProtocol: udp
@@ -232,7 +222,6 @@ Resources:
 
   BBBTurnSecurityGroupWebPlainTCPPort:
     Type: AWS::EC2::SecurityGroupIngress
-    Condition: BBBScalableEnvironment
     Properties:
       CidrIp: 0.0.0.0/0
       IpProtocol: tcp


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*

Fixed the following errors when setting `BBBEnvironmentType` as `single` by removing condition of `BBBScalableEnvironment` for security group rules, and adding `BBBTurnHostnameParameter` to `BBBAppStackSingle`

`Unresolved resource dependencies [BBBApplicationSecurityGroup] in the Outputs block of the template`
`Unresolved resource dependencies [BBBTurnSecurityGroup] in the Outputs block of the template`
`Parameters: [BBBTurnHostnameParameter] must have values`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
