### PR TITLE
Added Frontend HTTP to HTTPS Upgrade and Set Scalelite to present HTTPS…

### DIFF
--- a/templates/bbb-on-aws-frontendapps.template.yaml
+++ b/templates/bbb-on-aws-frontendapps.template.yaml
@@ -460,6 +460,22 @@ Resources:
       UnhealthyThresholdCount: 3
       VpcId: !Ref BBBVPCs
 
+  BBBFrontendALBListenerHTTP2HTTPS:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      DefaultActions:
+      - Type: redirect
+        RedirectConfig:
+          Host: "#{host}"
+          Path: "/#{path}"
+          Port: "443"
+          Protocol: "HTTPS"
+          Query: "#{query}"
+          StatusCode: "HTTP_301"
+      LoadBalancerArn: !Ref BBBFrontendALB
+      Port: 80
+      Protocol: HTTP
+
   BBBFrontendALBDNS:
     Type: AWS::Route53::RecordSetGroup
     Properties:
@@ -853,6 +869,8 @@ Resources:
                 - "redis://${BBBCacheDBAddress}:${BBBCacheDBPort}"
                 - BBBCacheDBAddress: !Ref BBBCacheDBAddress
                   BBBCacheDBPort: !Ref BBBCacheDBPort
+            - Name: BEHIND_PROXY
+              Value: true
         - Name: scalelite-api
           Essential: true
           Image: !Ref BBBScaleliteApiImage
@@ -1036,6 +1054,9 @@ Outputs:
   BBBFrontendALBListener:
     Description: Frontend Application Load Balancer Listener
     Value: !Ref BBBFrontendALBListener
+  BBBFrontendALBListenerHTTP2HTTPS:
+    Description: Frontend Application Load Balancer Listener HTTP Redirect
+    Value: !Ref BBBFrontendALBListenerHTTP2HTTPS
   BBBFrontendTG:
     Description: Frontend Application Load Balancer Target Group
     Value: !Ref BBBFrontendTG

--- a/templates/bbb-on-aws-securitygroups.template.yaml
+++ b/templates/bbb-on-aws-securitygroups.template.yaml
@@ -86,6 +86,15 @@ Resources:
       ToPort: 443
       GroupId: !Ref BBBFrontendELBSecurityGroup
 
+  BBBECSSecurityGroupPublicHTTP:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      CidrIp: 0.0.0.0/0
+      IpProtocol: tcp
+      FromPort: 80
+      ToPort: 80
+      GroupId: !Ref BBBFrontendELBSecurityGroup
+
   BBBFrontendSecurityGroupALBports:
     Type: AWS::EC2::SecurityGroupIngress
     Condition: BBBScalableEnvironment


### PR DESCRIPTION
… links

*Issue #, if available:*
#62 
*Description of changes:*

This is the Listener used to create HTTP to HTTPS redirect for Greenlight Frontend and the Security Group to allow it
Also Added Env variable to the Scalelite NGINX as to present presentation links via HTTPS in Greenlight instead of HTTP

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
