### PR TITLE
[Issue-62] Scalelite returns HTTPS Urls on API calls

### DIFF
--- a/templates/bbb-on-aws-frontendapps.template.yaml
+++ b/templates/bbb-on-aws-frontendapps.template.yaml
@@ -758,6 +758,10 @@ Resources:
                 - "redis://${BBBCacheDBAddress}:${BBBCacheDBPort}"
                 - BBBCacheDBAddress: !Ref BBBCacheDBAddress
                   BBBCacheDBPort: !Ref BBBCacheDBPort
+            - Name: BEHIND_PROXY
+              Value: 'true'
+            - Name: NGINX_BEHIND_PROXY
+              Value: 'true'
         - Name: scalelite-poller
           Essential: true
           Image: !Ref BBBScalelitePollerImage
@@ -789,6 +793,10 @@ Resources:
                 - "redis://${BBBCacheDBAddress}:${BBBCacheDBPort}"
                 - BBBCacheDBAddress: !Ref BBBCacheDBAddress
                   BBBCacheDBPort: !Ref BBBCacheDBPort
+            - Name: BEHIND_PROXY
+              Value: true
+            - Name: NGINX_BEHIND_PROXY
+              Value: 'true'
         - Name: scalelite-nginx
           Essential: true
           DependsOn:
@@ -853,6 +861,12 @@ Resources:
                 - "redis://${BBBCacheDBAddress}:${BBBCacheDBPort}"
                 - BBBCacheDBAddress: !Ref BBBCacheDBAddress
                   BBBCacheDBPort: !Ref BBBCacheDBPort
+            - Name: BEHIND_PROXY
+              Value: true
+            - Name: NGINX_BEHIND_PROXY
+              Value: 'true'
+            - Name: URL_HOST
+              Value: !Sub scalelite.${BBBDomainName}
         - Name: scalelite-api
           Essential: true
           Image: !Ref BBBScaleliteApiImage
@@ -897,6 +911,10 @@ Resources:
                 - "redis://${BBBCacheDBAddress}:${BBBCacheDBPort}"
                 - BBBCacheDBAddress: !Ref BBBCacheDBAddress
                   BBBCacheDBPort: !Ref BBBCacheDBPort
+            - Name: BEHIND_PROXY
+              Value: true
+            - Name: NGINX_BEHIND_PROXY
+              Value: 'true'
 
   BBBScaleliteAddServerTaskdefinition:
     Type: AWS::ECS::TaskDefinition


### PR DESCRIPTION
*Issue #, if available:*
fixes #62 

*Description of changes:*
Adding additional environment variable to the different scalelite containers. Detailed explenation:

We need both BEHIND_PROXY and NGINX_BEHIND_PROXY environment variables set to 'true' so that nginx forwards the original protocol and hostname (X-FORWARDED-FOR and X-FORWARDED-PROTO) to scalelite. This picks up them up and creates the proper URLs via the API.

Additionally, we need to set URL_HOST, but only for the nginx container. If we set this for the other, ELB Healthchecks will fail, because scalelite then only allows calls from that URL and not for the Ip Addresses of the tasks anymore.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
