### PR TITLE
Fixed error when BBBEnvironmentType is set as 'single' 

### DIFF
--- a/templates/bbb-on-aws-securitygroups.template.yaml
+++ b/templates/bbb-on-aws-securitygroups.template.yaml
@@ -88,6 +88,7 @@ Resources:
 
   BBBECSSecurityGroupPublicHTTP:
     Type: AWS::EC2::SecurityGroupIngress
+    Condition: BBBScalableEnvironment
     Properties:
       CidrIp: 0.0.0.0/0
       IpProtocol: tcp

--- a/templates/bbb-on-aws-securitygroups.template.yaml
+++ b/templates/bbb-on-aws-securitygroups.template.yaml
@@ -88,7 +88,6 @@ Resources:
 
   BBBECSSecurityGroupPublicHTTP:
     Type: AWS::EC2::SecurityGroupIngress
-    Condition: BBBScalableEnvironment
     Properties:
       CidrIp: 0.0.0.0/0
       IpProtocol: tcp


### PR DESCRIPTION
*Issue #81 :*

*Description of changes: Missing Line added. 

Line 91, "Condition: BBBScalableEnvironment" was missing in the "BBBECSSecurityGroupPublicHTTP" resource. Missing line caused the resource to point to a non-existing resource "BBBFrontendELBSecurityGroup" during _single_ server deployments, hence facing the error in Issue #81.  

By adding Line 91, the resource has to satisfy the Condition for it to be created. As the Condition is only applicable for scalable environments it is not created for single server deployments, hence resolving the issue. *


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
