### PR TITLE
3.0.7

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -2,7 +2,7 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
-## [3.0.6] - 2022-05-28
+## [3.0.7] - 2022-05-28
 
 ### Fixed
 - #113: Admin Password adds punktuation so greenlight bootstrapping does work again

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,6 +1,13 @@
 
 # Change Log
 All notable changes to this project will be documented in this file.
+
+## [3.0.6] - 2022-05-28
+
+### Fixed
+- #113: Admin Password adds punktuation so greenlight bootstrapping does work again
+- BBB Version pushed to 2.4 (2.3 seems broken atm)
+
 ## [3.0.4] - 2021-11-11
 
 ### Fixed

--- a/templates/bbb-on-aws-frontendapps.template.yaml
+++ b/templates/bbb-on-aws-frontendapps.template.yaml
@@ -307,7 +307,6 @@ Resources:
         SecretStringTemplate: !Sub "{\"username\":\"${BBBOperatorEMail}\"}"
         GenerateStringKey: 'password'
         PasswordLength: 16
-        ExcludePunctuation: true
 
   BBBScaleliteExecutionRole:
     Type: AWS::IAM::Role


### PR DESCRIPTION
## [3.0.7] - 2022-05-28

### Fixed
- #113: Admin Password adds punktuation so greenlight bootstrapping does work again
- BBB Version pushed to 2.4 (2.3 seems broken atm)